### PR TITLE
ソート済みの投稿を描画する

### DIFF
--- a/src/app/content.ts
+++ b/src/app/content.ts
@@ -2,8 +2,16 @@ import "../manifest.json"
 import "../styles/content.scss"
 import { html, render } from "lit-html"
 import DomObserver, { EventType } from "./kintone/dom-observer"
-import { getPosts, SortOrder, sortPostElements } from "./kintone/space-thread"
+import {
+  getPosts,
+  SortOrder,
+  sortPostElements,
+  insertCommentsWrapperElement,
+  hideOriginPosts,
+  renderPosts,
+} from "./kintone/space-thread"
 
+const SORTONE_COMMENTS_WRAPPER_CLASSNAME = "sortone-comments-wrapper"
 console.log("hoge")
 
 const sayHello = (name: String) => {
@@ -20,5 +28,15 @@ document.addEventListener(EventType.COMMENT_COMPONENT_LOADED, (e) => {
   console.log("comment component loaded", targetEl)
   const postEls = getPosts(targetEl)
   console.log(postEls)
-  console.log(sortPostElements(postEls, SortOrder.LIKE_DESC))
+  hideOriginPosts(postEls)
+  const sortedPosts = sortPostElements(postEls, SortOrder.LIKE_DESC)
+  console.log(sortedPosts)
+
+  const wrapperEl = insertCommentsWrapperElement(
+    SORTONE_COMMENTS_WRAPPER_CLASSNAME
+  )
+  if (!wrapperEl) {
+    return
+  }
+  renderPosts(sortedPosts, wrapperEl)
 })

--- a/src/app/kintone/space-thread.ts
+++ b/src/app/kintone/space-thread.ts
@@ -6,11 +6,52 @@ export const getPosts = (
   )
 }
 
+/**
+ * postElementsをsortOrderで指定した順序に入れ替える
+ * 返す値はshallow copyしたもの
+ * @param postElements
+ * @param sortOrder
+ */
 export const sortPostElements = (
   postElements: HTMLElement[],
   sortOrder: SortOrder
 ): HTMLElement[] => {
-  return sortInner_(postElements, sortOrder)
+  return sortInner_(postElements, sortOrder).concat()
+}
+
+export const insertCommentsWrapperElement = (
+  className: string
+): HTMLElement | null => {
+  const commentComponentEl = document.querySelector(
+    ".ocean-ui-comments-commentcomponent"
+  )
+  if (!commentComponentEl) {
+    return null
+  }
+  const wrapperEl = document.createElement("div")
+  wrapperEl.className = className
+  wrapperEl.style.border = "4px solid #cacaca"
+  commentComponentEl.insertAdjacentElement("afterend", wrapperEl)
+  return wrapperEl
+}
+
+export const hideOriginPosts = (commentElements: HTMLElement[]) => {
+  commentElements.forEach((el) => {
+    el.style.display = "none"
+  })
+}
+
+export const renderPosts = (
+  postElements: HTMLElement[],
+  container: HTMLElement
+) => {
+  container.append(
+    ...postElements.map((el) => {
+      // ここに来る前にdisplay: noneが指定される可能性があるのでプロパティを消す
+      el.style.removeProperty("display")
+      return el
+    })
+  )
 }
 
 const sortInner_ = (postElements: HTMLElement[], sortOrder: SortOrder) => {


### PR DESCRIPTION
Usage
```
// 既存の投稿を隠す、新着メッセージがありますの部分は残す
hideOriginPosts(postEls)

// 描画する基点を差し込む
const wrapperEl = insertCommentsWrapperElement(
    SORTONE_COMMENTS_WRAPPER_CLASSNAME
)
// 描画
renderPosts(sortedPosts, wrapperEl)
```