### PR TITLE
スクロールしたときにCommentComponentが表示されてしまうのを修正

### DIFF
--- a/src/app/content.ts
+++ b/src/app/content.ts
@@ -7,8 +7,8 @@ import {
   SortOrder,
   sortPostElements,
   insertCommentsWrapperElement,
-  hideOriginPosts,
   renderPosts,
+  hideOriginCommentComponent,
 } from "./kintone/space-thread"
 
 const SORTONE_COMMENTS_WRAPPER_CLASSNAME = "sortone-comments-wrapper"
@@ -28,7 +28,7 @@ document.addEventListener(EventType.COMMENT_COMPONENT_LOADED, (e) => {
   console.log("comment component loaded", targetEl)
   const postEls = getPosts(targetEl)
   console.log(postEls)
-  hideOriginPosts(postEls)
+  hideOriginCommentComponent()
   const sortedPosts = sortPostElements(postEls, SortOrder.LIKE_DESC)
   console.log(sortedPosts)
 

--- a/src/app/kintone/space-thread.ts
+++ b/src/app/kintone/space-thread.ts
@@ -35,10 +35,14 @@ export const insertCommentsWrapperElement = (
   return wrapperEl
 }
 
-export const hideOriginPosts = (commentElements: HTMLElement[]) => {
-  commentElements.forEach((el) => {
-    el.style.display = "none"
-  })
+export const hideOriginCommentComponent = () => {
+  const commentComponentEl = document.querySelector(
+    ".ocean-ui-comments-commentcomponent"
+  )
+  if (!commentComponentEl) {
+    return
+  }
+  ;(commentComponentEl as HTMLElement).style.display = "none"
 }
 
 export const renderPosts = (


### PR DESCRIPTION
CommentComponent内の投稿をdisplay: noneにしていたが、CommentComponentがスクロールによってある一定の場所に来たときにさらに表示が呼ばれてしまい、描画が行われてしまっていた
一時的にCommentComponentをすべてdisplay: noneにすることで回避
新着メッセージがうまくいかないのは #7 に任せる